### PR TITLE
Refactor

### DIFF
--- a/src/main/java/sparta/seed/campaign/service/CampaignService.java
+++ b/src/main/java/sparta/seed/campaign/service/CampaignService.java
@@ -75,11 +75,10 @@ public class CampaignService {
 			S3Dto upload = s3Uploader.upload(file);
 			Img findImage = Img.builder()
 					.imgUrl(upload.getUploadImageUrl())
-					.fileName(upload.getFileName())
 					.campaign(campaign)
 					.build();
 
-			if(findImage.getFileName().contains("[Thumbnail]")){
+			if(findImage.getImgUrl().contains("[Thumbnail]")){
 				campaign.setThumbnail(findImage.getImgUrl());
 				imgRepository.save(findImage);
 			}else {

--- a/src/main/java/sparta/seed/community/domain/Comment.java
+++ b/src/main/java/sparta/seed/community/domain/Comment.java
@@ -1,11 +1,9 @@
 package sparta.seed.community.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sparta.seed.img.domain.Img;
 import sparta.seed.util.Timestamped;
 
 import javax.persistence.*;
@@ -24,18 +22,15 @@ public class Comment extends Timestamped {
   private Long memberId;
   //내용
   private String content;
+  private String img;
   //인증글
   @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
   @JsonBackReference
   @JoinColumn(name = "proof_id")
   private Proof proof;
 
-  @OneToOne(mappedBy = "comment", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  @JsonManagedReference
-  private Img img;
-
   @Builder
-  public Comment(String nickname, Long memberId, String content, Img img, Proof proof) {
+  public Comment(String nickname, Long memberId, String content, String img, Proof proof) {
     this.nickname = nickname;
     this.memberId = memberId;
     this.content = content;
@@ -47,7 +42,7 @@ public class Comment extends Timestamped {
     this.content = content;
   }
 
-  public void setImg(Img img) {
+  public void setImg(String img) {
     this.img = img;
   }
 }

--- a/src/main/java/sparta/seed/community/domain/Comment.java
+++ b/src/main/java/sparta/seed/community/domain/Comment.java
@@ -25,12 +25,12 @@ public class Comment extends Timestamped {
   //내용
   private String content;
   //인증글
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
   @JsonBackReference
   @JoinColumn(name = "proof_id")
   private Proof proof;
 
-  @OneToOne(mappedBy = "comment", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+  @OneToOne(mappedBy = "comment", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   @JsonManagedReference
   private Img img;
 

--- a/src/main/java/sparta/seed/community/domain/Community.java
+++ b/src/main/java/sparta/seed/community/domain/Community.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import sparta.seed.community.domain.dto.requestdto.CommunityRequestDto;
-import sparta.seed.img.domain.Img;
 import sparta.seed.util.Timestamped;
 
 import javax.persistence.*;
@@ -29,6 +28,7 @@ public class Community extends Timestamped {
   private Long memberId;
   //내용
   private String content;
+  private String img;
   //캠페인시작일
   private String startDate;
   //캠페인마감일
@@ -47,9 +47,6 @@ public class Community extends Timestamped {
   @OneToMany(mappedBy = "community", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
   @JsonManagedReference
   private List<Proof> proofList = new ArrayList<>();
-  @OneToOne(mappedBy = "community", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-  @JsonManagedReference
-  private Img img;
 
   @OneToMany(mappedBy = "community", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
   @JsonManagedReference
@@ -57,12 +54,13 @@ public class Community extends Timestamped {
 
 
   @Builder
-  public Community(Long id, String title, String nickname, Long memberId, String content, String startDate, String endDate, long limitScore, long limitParticipants, boolean secret, String password, boolean recruitment, List<Proof> proofList, Img img, List<Participants> participantsList) {
+  public Community(Long id, String title, String nickname, Long memberId, String content, String img, String startDate, String endDate, long limitScore, long limitParticipants, boolean secret, String password, boolean recruitment, List<Proof> proofList, List<Participants> participantsList) {
     this.id = id;
     this.title = title;
     this.nickname = nickname;
     this.memberId = memberId;
     this.content = content;
+    this.img = img;
     this.startDate = startDate;
     this.endDate = endDate;
     this.limitScore = limitScore;
@@ -71,7 +69,6 @@ public class Community extends Timestamped {
     this.password = password;
     this.recruitment = recruitment;
     this.proofList = proofList;
-    this.img = img;
     this.participantsList = participantsList;
   }
 
@@ -90,7 +87,7 @@ public class Community extends Timestamped {
     participantsList.add(participants);
   }
 
-  public void setImg(Img img) {
+  public void setImg(String img) {
     this.img = img;
   }
 

--- a/src/main/java/sparta/seed/community/domain/Heart.java
+++ b/src/main/java/sparta/seed/community/domain/Heart.java
@@ -15,7 +15,7 @@ public class Heart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
     @JsonBackReference
     @JoinColumn(name = "proofId")
     private Proof proof;

--- a/src/main/java/sparta/seed/community/domain/Proof.java
+++ b/src/main/java/sparta/seed/community/domain/Proof.java
@@ -31,7 +31,7 @@ public class Proof extends Timestamped {
   private String content;
 
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
   @JsonBackReference
   @JoinColumn(name = "community_id")
   private Community community;
@@ -67,10 +67,6 @@ public class Proof extends Timestamped {
   public void addImg(Img img){
     this.imgList.add(img);
   }
-  public void removeImg(Img img){
-    this.imgList.remove(img);
-  }
-
   public void addComment(Comment comment){
     this.commentList.add(comment);
   }

--- a/src/main/java/sparta/seed/community/domain/dto/requestdto/CommentRequestDto.java
+++ b/src/main/java/sparta/seed/community/domain/dto/requestdto/CommentRequestDto.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public class CommentRequestDto {
 	private String content;
-	private Boolean delete;
+	private boolean delete;
 }

--- a/src/main/java/sparta/seed/community/domain/dto/requestdto/CommentRequestDto.java
+++ b/src/main/java/sparta/seed/community/domain/dto/requestdto/CommentRequestDto.java
@@ -5,4 +5,5 @@ import lombok.Getter;
 @Getter
 public class CommentRequestDto {
 	private String content;
+	private Boolean delete;
 }

--- a/src/main/java/sparta/seed/community/domain/dto/requestdto/CommunityRequestDto.java
+++ b/src/main/java/sparta/seed/community/domain/dto/requestdto/CommunityRequestDto.java
@@ -14,4 +14,5 @@ public class CommunityRequestDto {
   private String password;
   private String title;
   private String content;
+  private boolean delete;
 }

--- a/src/main/java/sparta/seed/community/domain/dto/responsedto/CommentResponseDto.java
+++ b/src/main/java/sparta/seed/community/domain/dto/responsedto/CommentResponseDto.java
@@ -2,7 +2,6 @@ package sparta.seed.community.domain.dto.responsedto;
 
 import lombok.Builder;
 import lombok.Getter;
-import sparta.seed.img.domain.Img;
 
 import java.time.LocalDate;
 
@@ -12,12 +11,12 @@ public class CommentResponseDto {
 	private LocalDate creatAt;
 	private String nickname;
 	private String content;
-	private Img img;
+	private String img;
 	private boolean writer;
 
 
 	@Builder
-	public CommentResponseDto(Long commentId, LocalDate creatAt, String nickname, String content, Img img, Boolean writer) {
+	public CommentResponseDto(Long commentId, LocalDate creatAt, String nickname, String content, String img, Boolean writer) {
 		this.commentId = commentId;
 		this.creatAt = creatAt;
 		this.nickname = nickname;

--- a/src/main/java/sparta/seed/community/domain/dto/responsedto/CommunityAllResponseDto.java
+++ b/src/main/java/sparta/seed/community/domain/dto/responsedto/CommunityAllResponseDto.java
@@ -2,14 +2,13 @@ package sparta.seed.community.domain.dto.responsedto;
 
 import lombok.Builder;
 import lombok.Getter;
-import sparta.seed.img.domain.Img;
 
 @Getter
 public class CommunityAllResponseDto {
 	private Long communityId;
 	private String nickname;
 	private String title;
-	private Img img;
+	private String img;
 	private double currentPercent;
 	private double successPercent;
 	private String dateStatus;
@@ -18,7 +17,7 @@ public class CommunityAllResponseDto {
 	private boolean writer;
 
 	@Builder
-	public CommunityAllResponseDto(Long communityId, String nickname, String title, Img img, double currentPercent, double successPercent, String dateStatus, boolean secret, String password, boolean writer) {
+	public CommunityAllResponseDto(Long communityId, String nickname, String title, String img, double currentPercent, double successPercent, String dateStatus, boolean secret, String password, boolean writer) {
 		this.communityId = communityId;
 		this.nickname = nickname;
 		this.title = title;

--- a/src/main/java/sparta/seed/community/domain/dto/responsedto/CommunityMyJoinResponseDto.java
+++ b/src/main/java/sparta/seed/community/domain/dto/responsedto/CommunityMyJoinResponseDto.java
@@ -2,16 +2,15 @@ package sparta.seed.community.domain.dto.responsedto;
 
 import lombok.Builder;
 import lombok.Getter;
-import sparta.seed.img.domain.Img;
 
 @Getter
 public class CommunityMyJoinResponseDto {
 	private Long communityId;
 	private String title;
-	private Img img;
+	private String img;
 
 	@Builder
-	public CommunityMyJoinResponseDto(Long communityId, String title, Img img) {
+	public CommunityMyJoinResponseDto(Long communityId, String title, String img) {
 		this.communityId = communityId;
 		this.title = title;
 		this.img = img;

--- a/src/main/java/sparta/seed/community/domain/dto/responsedto/CommunityResponseDto.java
+++ b/src/main/java/sparta/seed/community/domain/dto/responsedto/CommunityResponseDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import sparta.seed.community.domain.Participants;
-import sparta.seed.img.domain.Img;
 
 import java.util.List;
 
@@ -20,7 +19,7 @@ public class CommunityResponseDto {
   private String nickname;
   private String title;
   private String content;
-  private Img img;
+  private String img;
   //모임 참가자
   private List<Participants> participantsList;
   private Integer participantsCnt;
@@ -43,7 +42,7 @@ public class CommunityResponseDto {
 
   @QueryProjection
   @Builder
-  public CommunityResponseDto(Long communityId, Img img, String title, boolean participant, List<Participants> participantsList, long limitScore, long limitParticipants, double successPercent, double currentPercent, Integer participantsCnt, String nickname, String startDate, String endDate, boolean secret, String password, String content, String dateStatus, String createAt, boolean writer) {
+  public CommunityResponseDto(Long communityId, String img, String title, boolean participant, List<Participants> participantsList, long limitScore, long limitParticipants, double successPercent, double currentPercent, Integer participantsCnt, String nickname, String startDate, String endDate, boolean secret, String password, String content, String dateStatus, String createAt, boolean writer) {
     this.communityId = communityId;
     this.createAt = createAt;
     this.nickname = nickname;

--- a/src/main/java/sparta/seed/community/service/CommentService.java
+++ b/src/main/java/sparta/seed/community/service/CommentService.java
@@ -13,7 +13,6 @@ import sparta.seed.community.repository.CommentRepository;
 import sparta.seed.community.repository.ProofRepository;
 import sparta.seed.exception.CustomException;
 import sparta.seed.exception.ErrorCode;
-import sparta.seed.img.repository.ImgRepository;
 import sparta.seed.msg.ResponseMsg;
 import sparta.seed.s3.S3Uploader;
 import sparta.seed.sercurity.UserDetailsImpl;
@@ -27,7 +26,6 @@ import java.util.List;
 public class CommentService {
 	private final ProofRepository proofRepository;
 	private final CommentRepository commentRepository;
-	private final ImgRepository imgRepository;
 	private final S3Uploader s3Uploader;
 
 	/**
@@ -86,7 +84,7 @@ public class CommentService {
 		if (userDetails != null && comment.getMemberId().equals(userDetails.getId())) {
 			comment.update(commentRequestDto.getContent());
 
-				if (commentRequestDto.getDelete() | multipartFile != null) {
+				if (commentRequestDto.isDelete() | multipartFile != null) {
 					comment.setImg(returnImageUrl(multipartFile));
 				}
 

--- a/src/main/java/sparta/seed/community/service/CommunityService.java
+++ b/src/main/java/sparta/seed/community/service/CommunityService.java
@@ -20,7 +20,6 @@ import sparta.seed.community.repository.ParticipantsRepository;
 import sparta.seed.community.repository.ProofRepository;
 import sparta.seed.exception.CustomException;
 import sparta.seed.exception.ErrorCode;
-import sparta.seed.img.repository.ImgRepository;
 import sparta.seed.msg.ResponseMsg;
 import sparta.seed.s3.S3Uploader;
 import sparta.seed.sercurity.UserDetailsImpl;
@@ -36,7 +35,6 @@ import java.util.List;
 public class CommunityService {
 
   private final CommunityRepository communityRepository;
-  private final ImgRepository imgRepository;
   private final S3Uploader s3Uploader;
   private final ParticipantsRepository participantsRepository;
   private final DateUtil dateUtil;

--- a/src/main/java/sparta/seed/community/service/ProofService.java
+++ b/src/main/java/sparta/seed/community/service/ProofService.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import sparta.seed.community.repository.HeartRepository;
 import sparta.seed.community.domain.Community;
 import sparta.seed.community.domain.Heart;
 import sparta.seed.community.domain.Proof;
@@ -17,6 +16,7 @@ import sparta.seed.community.domain.dto.responsedto.ProofCountResponseDto;
 import sparta.seed.community.domain.dto.responsedto.ProofHeartResponseDto;
 import sparta.seed.community.domain.dto.responsedto.ProofResponseDto;
 import sparta.seed.community.repository.CommunityRepository;
+import sparta.seed.community.repository.HeartRepository;
 import sparta.seed.community.repository.ParticipantsRepository;
 import sparta.seed.community.repository.ProofRepository;
 import sparta.seed.exception.CustomException;
@@ -28,7 +28,6 @@ import sparta.seed.s3.S3Dto;
 import sparta.seed.s3.S3Uploader;
 import sparta.seed.sercurity.UserDetailsImpl;
 
-import javax.transaction.Transactional;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -222,7 +221,6 @@ public class ProofService {
 				S3Dto upload = s3Uploader.upload(file);
 				Img findImage = Img.builder()
 						.imgUrl(upload.getUploadImageUrl())
-						.fileName(upload.getFileName())
 						.proof(proof)
 						.build();
 				proof.addImg(findImage);

--- a/src/main/java/sparta/seed/community/service/ProofService.java
+++ b/src/main/java/sparta/seed/community/service/ProofService.java
@@ -101,7 +101,6 @@ public class ProofService {
 	/**
 	 * 인증글 수정
 	 */
-	@Transactional
 	public ResponseEntity<String> updateProof(Long proofId, ProofRequestDto proofRequestDto,
 	                                                    List<MultipartFile> multipartFile, UserDetailsImpl userDetails) throws IOException {
 		Proof proof = findTheProofById(proofId);
@@ -230,6 +229,6 @@ public class ProofService {
 				imgList.add(findImage);
 			}else throw new CustomException(ErrorCode.EXCEED_IMG_CNT);
 		}
-		imgRepository.saveAll(imgList);
+		proofRepository.save(proof);
 	}
 }

--- a/src/main/java/sparta/seed/img/domain/Img.java
+++ b/src/main/java/sparta/seed/img/domain/Img.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sparta.seed.campaign.domain.Campaign;
-import sparta.seed.community.domain.Comment;
-import sparta.seed.community.domain.Community;
 import sparta.seed.community.domain.Proof;
 import sparta.seed.util.Timestamped;
 
@@ -22,12 +20,6 @@ public class Img extends Timestamped {
   private Long id;
 
   private String imgUrl;
-  private String fileName;
-
-  @OneToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
-  @JsonBackReference
-  @JoinColumn(name = "CommunityId")
-  private Community community;
 
   @ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
   @JsonBackReference
@@ -39,19 +31,11 @@ public class Img extends Timestamped {
   @JoinColumn(name = "campaignId")
   private Campaign campaign;
 
-  @OneToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
-  @JsonBackReference
-  @JoinColumn(name = "commentId")
-  private Comment comment;
-
   @Builder
-  public Img(Long id, String imgUrl, String fileName, Community community, Proof proof, Campaign campaign, Comment comment) {
+  public Img(Long id, String imgUrl, Proof proof, Campaign campaign) {
     this.id = id;
     this.imgUrl = imgUrl;
-    this.fileName = fileName;
-    this.community = community;
     this.proof = proof;
     this.campaign = campaign;
-    this.comment = comment;
   }
 }

--- a/src/main/java/sparta/seed/img/repository/ImgRepository.java
+++ b/src/main/java/sparta/seed/img/repository/ImgRepository.java
@@ -2,14 +2,9 @@ package sparta.seed.img.repository;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import sparta.seed.community.domain.Comment;
-import sparta.seed.community.domain.Community;
-import sparta.seed.community.domain.Proof;
 import sparta.seed.img.domain.Img;
 
 public interface
 ImgRepository extends JpaRepository<Img,Long> {
-	Img findByComment(Comment comment);
-	Img findByCommunity(Community community);
-	Img findByProofAndId(Proof proof, Long id);
+
 }

--- a/src/main/java/sparta/seed/member/service/MemberService.java
+++ b/src/main/java/sparta/seed/member/service/MemberService.java
@@ -68,7 +68,7 @@ public class MemberService {
         .orElseThrow(()-> new CustomException(ErrorCode.UNKNOWN_USER));
     if (!(member.getNickname().equals(requestDto.getNickname()) && memberRepository.existsByNickname(requestDto.getNickname()))) {
       member.updateNickname(requestDto);
-      return ResponseEntity.badRequest().body(NicknameResponseDto.builder()
+      return ResponseEntity.ok().body(NicknameResponseDto.builder()
           .nickname(member.getNickname())
           .success(true)
           .build());
@@ -121,12 +121,13 @@ public class MemberService {
    */
   @Transactional
   public ResponseEntity<Boolean> isSceret(UserDetailsImpl userDetails) {
-    Optional<Member> member = memberRepository.findById(userDetails.getId());
-    if (!member.get().isSecret()) {
-      member.get().updateIsSecret(true);
+    Member member = memberRepository.findById(userDetails.getId())
+            .orElseThrow(()-> new CustomException(ErrorCode.UNKNOWN_USER));
+    if (!member.isSecret()) {
+      member.updateIsSecret(true);
       return ResponseEntity.ok().body(true);
     }
-    member.get().updateIsSecret(false);
+    member.updateIsSecret(false);
     return ResponseEntity.ok().body(false);
   }
 


### PR DESCRIPTION
아까 말씀드린 커뮤니티나 댓글 수정 시 이미지 삭제 부분을 따로 api로 안 만들고 수정 api에 포함시켰어요
생각해보니 만약 유저가 이미지를 삭제했다가 수정을 완료하지 않고 뒤로가기를 눌렀을 때
이미지 삭제 api가 따로 있으면 이미지 삭제를 취소할 방법이 없어서 트랜젝션 안으로 묶었습니다

핵심 변경 사항은 CommunityService와 CommentService인데 둘의 로직 변경 사항이 동일해서 부피가 작은 CommentService를 위주로 보시면 됩니다.
1. 파일 맨 아래에 multipartFile을 파라미터로 받는 returnImageUrl메서드가 추가되었습니다. multipartFile이 null이 아닐경우 url를 리턴하고 null일 경우 null을 리턴합니다.
2. 수정 api 리퀘스트에 delete라는 불리언 값을 추가했습니다. 사용자가 이미지를 삭제할 경우 프론트에서 true를 주기로 했고, 삭제하지 않을 경우 false를 주기로 했습니다.
3. 수정 로직에서 delete값이 true일 때 or multipartFile이 null 아닐 때를 추가한 이유는 만약 기존에 사진이 없던 댓글에 사용자가 사진을 올리게 될 경우 프론트에서 주는 delete값이 false일수도 있기 때문에 사진이 오는 경우엔 무조건 returnImageUrl메서드를 실행하도록 하기 위함입니다.